### PR TITLE
Refactor: separate stats calculation from printing

### DIFF
--- a/flex_nano_vllm/inference.py
+++ b/flex_nano_vllm/inference.py
@@ -461,7 +461,7 @@ class Inference:
         )
         # in our code, the page table tensors are modified in-place, so we don't need to put them in graph vars
 
-    def print_time_stats(self, times):
+    def _calculate_time_stats(self, times: list[dict]) -> dict:
         stats = {}
         for step in ["decode", "prefill"]:
             step_times = [t["time"] for t in times if t["step_type"] == step]
@@ -472,13 +472,19 @@ class Inference:
                 "min": min(step_times) if step_times else 0,
                 "max": max(step_times) if step_times else 0,
             }
+        stats["total_time"] = sum(t['time'] for t in times)
+        return stats
 
+    def print_time_stats(self, times: list[dict]):
+        stats = self._calculate_time_stats(times)
         print("\nTime statistics by step type:")
         for step, metrics in stats.items():
+            if step == "total_time":
+                continue
             print(f"\n{step}:")
             print(f"  Count: {metrics['count']}")
             print(f"  Total: {metrics['total']:.4f}s")
             print(f"  Mean:  {metrics['mean']:.4f}s")
             print(f"  Min:   {metrics['min']:.4f}s")
             print(f"  Max:   {metrics['max']:.4f}s")
-        print(f"\nTotal time: {sum(t['time'] for t in times):.4f}s")
+        print(f"\nTotal time: {stats['total_time']:.4f}s")


### PR DESCRIPTION
 This pull request refactors the print_time_stats method in
  flex_nano_vllm/inference.py to improve code structure and separate concerns.

  The original implementation mixed the logic for calculating performance
  statistics (e.g., mean, min, max) with the logic for printing them to the
  console. This coupling made the code less modular and harder to test or
  reuse.

  This refactoring introduces a new private method, _calculate_time_stats,
  which is now solely responsible for processing the timing data and
  calculating the relevant metrics. The print_time_stats method has been
  updated to call this new method and now only handles the formatting and
  presentation of the statistics.

  This change improves the overall code quality by enforcing a clear
  separation between data processing and presentation, making the logic more
  maintainable and reusable.